### PR TITLE
Remove unused mongodb-ns dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
     "mocha": "^3.1.2",
     "mongodb": "^2.1.12",
     "mongodb-connection-model": "^6.3.1",
-    "mongodb-reflux-store": "^0.0.1",
     "mongodb-data-service": "^2.1.0",
     "mongodb-js-cli": "^0.0.3",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.8",
+    "mongodb-reflux-store": "^0.0.1",
     "mongodb-runner": "^3.1.15",
-    "mongodb-ns": "^1.0.3",
     "react-addons-test-utils": "^15.3.2",
     "spectron": "^3.4.0"
   }


### PR DESCRIPTION
npm uninstall --save mongodb-ns

There is no usage of `require('mongodb-ns')`, ES6 imports or anything similar anywhere in this dependency. Note that it is transitively used, for example by mongodb-data-service.